### PR TITLE
Changes required for Elixir 1.1

### DIFF
--- a/lib/mimemail.ex
+++ b/lib/mimemail.ex
@@ -2,7 +2,6 @@ defmodule MimeMail do
   @type header :: {:raw,binary} | MimeMail.Header.t #ever the raw line or any term implementing MimeMail.Header.to_ascii
   @type body :: binary | [MimeMail.t] | {:raw,binary} #ever the raw body or list of mail for multipart or binary for decoded content
   @type t :: %MimeMail{headers: [{key::binary,header}], body: body}
-  @derive [Access]
   defstruct headers: [], body: ""
 
   def from_string(data) do
@@ -39,7 +38,7 @@ defmodule MimeMail do
       _ -> body
     end
     body = case headers[:'content-type'] do
-      {"multipart/"<>_,%{boundary: bound}}-> 
+      {"multipart/"<>_,%{boundary: bound}}->
         body |> String.split(~r"\s*--#{bound}\s*") |> Enum.slice(1..-2) |> Enum.map(&from_string/1) |> Enum.map(&decode_body/1)
       {"text/"<>_,%{charset: charset}} ->
         body |> Iconv.conv(charset,"utf8") |> ok_or(ensure_ascii(body)) |> ensure_utf8
@@ -53,7 +52,7 @@ defmodule MimeMail do
   def encode_body(%MimeMail{body: body}=mail) when is_binary(body) do
     mail = MimeMail.CTParams.decode_headers(mail)
     case mail.headers[:'content-type'] do
-      {"text/"<>_=type,params}-> 
+      {"text/"<>_=type,params}->
         headers = Dict.drop(mail.headers,[:'content-type',:'content-transfer-encoding']) ++[
           'content-type': {type,Dict.put(params,:charset,"utf-8")},
           'content-transfer-encoding': "quoted-printable"
@@ -93,19 +92,19 @@ defmodule MimeMail do
   defp chunk_line(<<vline::size(74)-binary,?=,rest::binary>>), do: (vline<>"=\r\n"<>chunk_line("="<>rest))
   defp chunk_line(<<vline::size(75)-binary,rest::binary>>), do: (vline<>"=\r\n"<>chunk_line(rest))
   defp chunk_line(other), do: other
-  
-  def qp_to_binary(str), do: 
+
+  def qp_to_binary(str), do:
     (str |> String.rstrip |> String.rstrip(?=) |> qp_to_binary([]))
-  def qp_to_binary("=\r\n"<>rest,acc), do: 
+  def qp_to_binary("=\r\n"<>rest,acc), do:
     qp_to_binary(rest,acc)
-  def qp_to_binary(<<?=,x1,x2>><>rest,acc), do: 
+  def qp_to_binary(<<?=,x1,x2>><>rest,acc), do:
     qp_to_binary(rest,[<<x1,x2>> |> String.upcase |> Base.decode16! | acc])
   def qp_to_binary(<<c,rest::binary>>,acc), do:
     qp_to_binary(rest,[c | acc])
   def qp_to_binary("",acc), do:
     (acc |> Enum.reverse |> IO.iodata_to_binary)
 
-  def unfold_header(value), do: 
+  def unfold_header(value), do:
     String.replace(value,~r/\r\n([\t ])/,"\\1")
 
   def fold_header(header), do:
@@ -130,7 +129,7 @@ defmodule MimeMail do
   def ensure_ascii(bin), do:
     Kernel.to_string(for(<<c<-bin>>, (c<127 and c>31) or c in [?\t,?\r,?\n], do: c))
   def ensure_utf8(bin) do
-    bin 
+    bin
     |> String.chunk(:printable)
     |> Enum.filter(&String.printable?/1)
     |> Kernel.to_string

--- a/mix.exs
+++ b/mix.exs
@@ -17,8 +17,8 @@ defmodule Mailibex.Mixfile do
 
   def project do
     [app: :mailibex,
-     version: "0.0.1",
-     elixir: "~> 1.0.0",
+     version: "0.1.0",
+     elixir: "~> 1.1",
      description: description,
      package: package,
      compilers: [:iconv, :elixir, :app],

--- a/test/dkim_test.exs
+++ b/test/dkim_test.exs
@@ -46,7 +46,7 @@ defmodule DKIMTest do
 
   test "DKIM signature round trip" do
     [rsaentry] =  :public_key.pem_decode(File.read!("test/mails/key.pem"))
-    assert {:pass,_} = 
+    assert {:pass,_} =
       File.read!("test/mails/valid_dkim_relaxed_canon.eml")
       |> MimeMail.from_string
       |> DKIM.sign(:public_key.pem_entry_decode(rsaentry), d: "order.brendy.fr", s: "cobrason")

--- a/test/flat_mail_test.exs
+++ b/test/flat_mail_test.exs
@@ -8,7 +8,7 @@ defmodule FlatMailTest do
     assert {"text/plain",%{}} = text.headers[:'content-type']
     assert {"text/plain",%{name: ct_txt_name}} = text_attached.headers[:'content-type']
     assert {"application/x-7z-compressed",%{name: ct_7z_name}} = archive.headers[:'content-type']
-    assert nil = text.headers[:'content-disposition']
+    assert nil == text.headers[:'content-disposition']
     assert {"attachment",%{filename: cd_txt_name}} = text_attached.headers[:'content-disposition']
     assert {"attachment",%{filename: cd_7z_name}} = archive.headers[:'content-disposition']
     assert String.contains?(ct_txt_name,".txt")
@@ -34,7 +34,7 @@ defmodule FlatMailTest do
     assert ".txt" = MimeTypes.bin2ext(txt)
     assert ".html" = MimeTypes.bin2ext(html)
     assert ".png" = MimeTypes.bin2ext(png)
-    flat = flat 
+    flat = flat
     |> MimeMail.Flat.to_mail
     |> MimeMail.to_string
     |> MimeMail.from_string

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -12,7 +12,7 @@ defmodule MimeMailTest do
   test "qp encoding => no line > 76 char && only ascii && no space at end of lines" do
     res = MimeMail.string_to_qp(@qp_test)
     Enum.each String.split(res,"\r\n"), fn line->
-      assert false = Regex.match? ~r/[\t ]+$/, line
+      assert false == Regex.match? ~r/[\t ]+$/, line
       assert String.length(line) < 77
       assert [] = Enum.filter('#{line}',&(&1 < 32 or &1 > 127))
     end
@@ -85,9 +85,9 @@ defmodule MimeMailTest do
     |> MimeMail.from_string
     |> MimeMail.decode_headers([DKIM,MimeMail.Emails,MimeMail.Words,MimeMail.CTParams])
     |> MimeMail.decode_body
-    roundtrip = decoded 
-    |> MimeMail.to_string 
-    |> MimeMail.from_string 
+    roundtrip = decoded
+    |> MimeMail.to_string
+    |> MimeMail.from_string
     |> MimeMail.decode_body
     assert String.rstrip(decoded.body) == String.rstrip(roundtrip.body)
   end


### PR DESCRIPTION
There's a test still failing here, but I don't know if it was failing before.  It's this one:

```
  1) test TLD with only 1 (wildcard) rule. (DMARCTest)
     test/dmarc_test.exs:32
     match (=) failed
     code: "b.c.cy" = DMARC.organization("b.c.cy")
     rhs:  "c.cy"
     stacktrace:
       test/dmarc_test.exs:35
```

I don't see that any of these changes would have affected that though...
