### PR TITLE
Handle commas appropriately

### DIFF
--- a/lib/mimemail_headers.ex
+++ b/lib/mimemail_headers.ex
@@ -1,10 +1,19 @@
 defmodule MimeMail.Address do
   defstruct name: nil, address: ""
 
+  @behaviour Access
+  defdelegate get_and_update(dict,k,v), to: Map
+  defdelegate fetch(dict,k), to: Map
+  defdelegate get(dict,k,v), to: Map
+  defdelegate pop(dict,k), to: Map
+
   def decode(addr_spec) do
-    case Regex.run(~r/^([^<]*)<([^>]*)>/,addr_spec) do
-      [_,desc,addr]->%MimeMail.Address{name: MimeMail.Words.word_decode(desc), address: addr}
-      _ -> %MimeMail.Address{name: nil, address: String.strip(addr_spec)}
+    case Regex.run(~r/^([^<]*)<([^>]*)>/, addr_spec) do
+      [_, desc, addr] ->
+        name = desc |> MimeMail.Words.word_decode() |> String.trim("\"")
+        %MimeMail.Address{name: name, address: addr}
+      _ ->
+        %MimeMail.Address{name: nil, address: String.strip(addr_spec)}
     end
   end
 
@@ -17,7 +26,7 @@ end
 
 defmodule MimeMail.Emails do
   def parse_header(data) do
-    data |> String.strip |> String.split(~r/\s*,\s*/) |> Enum.map(&MimeMail.Address.decode/1)
+    data |> String.strip |> String.split(~r/(?!\B"[^"]*),(?![^"]*"\B)/) |> Enum.map(&MimeMail.Address.decode/1)
   end
   def decode_headers(%MimeMail{headers: headers}=mail) do
     parsed=for {k,{:raw,v}}<-headers, k in [:from,:to,:cc,:cci,:'delivered-to'] do
@@ -27,7 +36,7 @@ defmodule MimeMail.Emails do
   end
   defimpl MimeMail.Header, for: List do # a list header is a mailbox spec list
     def to_ascii(mail_list) do # a mail is a struct %{name: nil, address: ""}
-      mail_list 
+      mail_list
       |> Enum.filter(&match?(%MimeMail.Address{},&1))
       |> Enum.map(&MimeMail.Header.to_ascii/1) |> Enum.join(", ")
     end
@@ -37,13 +46,13 @@ end
 defmodule MimeMail.Params do
   def parse_header(bin), do: parse_kv(bin<>";",:key,[],[])
 
-  def parse_kv(<<c,rest::binary>>,:key,keyacc,acc) when c in [?\s,?\t,?\r,?\n,?;], do: 
+  def parse_kv(<<c,rest::binary>>,:key,keyacc,acc) when c in [?\s,?\t,?\r,?\n,?;], do:
     parse_kv(rest,:key,keyacc,acc) # not allowed characters in key, skip
-  def parse_kv(<<?=,?",rest::binary>>,:key,keyacc,acc), do: 
+  def parse_kv(<<?=,?",rest::binary>>,:key,keyacc,acc), do:
     parse_kv(rest,:quotedvalue,[],[{:"#{keyacc|>Enum.reverse|>to_string|>String.downcase}",""}|acc]) # enter in a quoted value, save key in res acc
-  def parse_kv(<<?=,rest::binary>>,:key,keyacc,acc), do: 
+  def parse_kv(<<?=,rest::binary>>,:key,keyacc,acc), do:
     parse_kv(rest,:value,[],[{:"#{keyacc|>Enum.reverse|>to_string|>String.downcase}",""}|acc]) # enter in a simple value, save key in res acc
-  def parse_kv(<<c,rest::binary>>,:key,keyacc,acc), do: 
+  def parse_kv(<<c,rest::binary>>,:key,keyacc,acc), do:
     parse_kv(rest,:key,[c|keyacc],acc) # allowed char in key, add to key acc
   def parse_kv(<<?\\,?",rest::binary>>,:quotedvalue,valueacc,acc), do:
     parse_kv(rest,:quotedvalue,[?"|valueacc],acc) # \" in quoted value is "
@@ -69,7 +78,7 @@ defmodule MimeMail.CTParams do
       [value] -> {value,%{}}
     end
   end
-  def normalize({value,m},k) when k in 
+  def normalize({value,m},k) when k in
     [:"content-type",:"content-transfer-encoding",:"content-disposition"], do: {String.downcase(value),m}
   def normalize(h,_), do: h
   def decode_headers(%MimeMail{headers: headers}=mail) do
@@ -91,7 +100,7 @@ defmodule MimeMail.Words do
   def word_encode(line) do
     if is_ascii(line) do line else
       for <<char::utf8<-line>> do
-        case char do 
+        case char do
           ?\s -> ?_
           c when c < 127 and c > 32 and c !== ?= and c !== ?? and c !== ?_-> c
           c -> for(<<a,b<-Base.encode16(<<c::utf8>>)>>,into: "",do: <<?=,a,b>>)
@@ -121,9 +130,9 @@ defmodule MimeMail.Words do
   end
   def single_word_decode(str), do: "#{str} "
 
-  def q_to_binary("_"<>rest,acc), do: 
+  def q_to_binary("_"<>rest,acc), do:
     q_to_binary(rest,[?\s|acc])
-  def q_to_binary(<<?=,x1,x2>><>rest,acc), do: 
+  def q_to_binary(<<?=,x1,x2>><>rest,acc), do:
     q_to_binary(rest,[<<x1,x2>> |> String.upcase |> Base.decode16! | acc])
   def q_to_binary(<<c,rest::binary>>,acc), do:
     q_to_binary(rest,[c | acc])


### PR DESCRIPTION
As per [RFC2822](https://www.ietf.org/rfc/rfc2822.txt) wherein the mailbox-list and mailbox specifications are defined, the following format should be permissible per § 3.4:

"LastName, FirstName" <mailbox@domain.tld>
This PR handles that appropriately.

---

This PR also adds Access behaviour so that the bracket syntax can be used, this is useful for drilling down like this:

m = %MimeMail{}
m[:headers][:from]