### PR TITLE
Escape boundaries on multipart email regex match

### DIFF
--- a/lib/mimemail.ex
+++ b/lib/mimemail.ex
@@ -49,8 +49,8 @@ defmodule MimeMail do
       _ -> body
     end
     body = case headers[:'content-type'] do
-      {"multipart/"<>_,%{boundary: bound}}-> 
-        body |> String.split(~r"\s*--#{bound}\s*") |> Enum.slice(1..-2) |> Enum.map(&from_string/1) |> Enum.map(&decode_body/1)
+      {"multipart/"<>_,%{boundary: bound}}->
+        body |> String.split(~r"\s*--#{Regex.escape(bound)}\s*") |> Enum.slice(1..-2) |> Enum.map(&from_string/1) |> Enum.map(&decode_body/1)
       {"text/"<>_,%{charset: charset}} ->
         body |> Iconv.conv(charset,"utf8") |> ok_or(ensure_ascii(body)) |> ensure_utf8
       _ -> body
@@ -63,7 +63,7 @@ defmodule MimeMail do
   def encode_body(%MimeMail{body: body}=mail) when is_binary(body) do
     mail = MimeMail.CTParams.decode_headers(mail)
     case mail.headers[:'content-type'] do
-      {"text/"<>_=type,params}-> 
+      {"text/"<>_=type,params}->
         headers = Dict.drop(mail.headers,[:'content-type',:'content-transfer-encoding']) ++[
           'content-type': {type,Dict.put(params,:charset,"utf-8")},
           'content-transfer-encoding': "quoted-printable"
@@ -103,19 +103,19 @@ defmodule MimeMail do
   defp chunk_line(<<vline::size(74)-binary,?=,rest::binary>>), do: (vline<>"=\r\n"<>chunk_line("="<>rest))
   defp chunk_line(<<vline::size(75)-binary,rest::binary>>), do: (vline<>"=\r\n"<>chunk_line(rest))
   defp chunk_line(other), do: other
-  
-  def qp_to_binary(str), do: 
+
+  def qp_to_binary(str), do:
     (str |> String.rstrip |> String.rstrip(?=) |> qp_to_binary([]))
-  def qp_to_binary("=\r\n"<>rest,acc), do: 
+  def qp_to_binary("=\r\n"<>rest,acc), do:
     qp_to_binary(rest,acc)
-  def qp_to_binary(<<?=,x1,x2>><>rest,acc), do: 
+  def qp_to_binary(<<?=,x1,x2>><>rest,acc), do:
     qp_to_binary(rest,[<<x1,x2>> |> String.upcase |> Base.decode16! | acc])
   def qp_to_binary(<<c,rest::binary>>,acc), do:
     qp_to_binary(rest,[c | acc])
   def qp_to_binary("",acc), do:
     (acc |> Enum.reverse |> IO.iodata_to_binary)
 
-  def unfold_header(value), do: 
+  def unfold_header(value), do:
     String.replace(value,~r/\r\n([\t ])/,"\\1")
 
   def fold_header(header), do:
@@ -140,7 +140,7 @@ defmodule MimeMail do
   def ensure_ascii(bin), do:
     Kernel.to_string(for(<<c<-bin>>, (c<127 and c>31) or c in [?\t,?\r,?\n], do: c))
   def ensure_utf8(bin) do
-    bin 
+    bin
     |> String.chunk(:printable)
     |> Enum.filter(&String.printable?/1)
     |> Kernel.to_string

--- a/test/mails/free.eml
+++ b/test/mails/free.eml
@@ -26,14 +26,14 @@ From: Assistance Free <pasreponse@assistance.free.fr>
 ID-Courrier: 28601953
 MIME-Version: 1.0
 Content-Type: multipart/alternative;
- boundary="_NextPart_529786cba680f4cda8c47a92f2d7e09d"
+ boundary="_NextPart_(529786cba680f4cda8c47a92f2d7e09d)"
 Message-Id: <20141107091504.E2BA4958020@grosminet-cron.centrapel.com>
 Date: Fri,  7 Nov 2014 10:15:04 +0100 (CET)
 
 
 
 
---_NextPart_529786cba680f4cda8c47a92f2d7e09d
+--_NextPart_(529786cba680f4cda8c47a92f2d7e09d)
 Content-Type: text/plain; charset="iso-8859-1"
 Content-Transfer-Encoding: 8bit
 
@@ -55,7 +55,7 @@ Depuis un autre numéro : se référer à la grille tarifaire de l'opérateur
 Web : http://assistance.free.fr/
 Adresse : Free Haut Débit 75371 PARIS CEDEX 08Free – 75371 Paris Cedex 08 – http://www.free.fr/
 S.A.S au capital de 3.441.812 Euros – R.C.S. Paris : B 421 938 861 – N° TVA intra communautaire : FR 604 219 388 61
---_NextPart_529786cba680f4cda8c47a92f2d7e09d
+--_NextPart_(529786cba680f4cda8c47a92f2d7e09d)
 Content-Type: multipart/related;
  boundary="_MixedPart_12c208616ad3684897f2a5137a7d00b1"
 
@@ -296,5 +296,5 @@ D8QoG6Tj7wNzAAAAAElFTkSuQmCC
 
 
 --_MixedPart_12c208616ad3684897f2a5137a7d00b1--
---_NextPart_529786cba680f4cda8c47a92f2d7e09d--
+--_NextPart_(529786cba680f4cda8c47a92f2d7e09d)--
 


### PR DESCRIPTION
When we are decoding the body of a multipart email, we interpolate the boundaries string to use for regex matching. However, this string is not escaped, thus leading to issues decoding boundaries with special regex chars like: Boundary_(ID_blahblahblahblah). This PR hopes to fix that